### PR TITLE
Install libgit2 side-by-side

### DIFF
--- a/pygit2/version.py
+++ b/pygit2/version.py
@@ -24,3 +24,4 @@
 # Boston, MA 02110-1301, USA.
 
 __version__ = '0.20.2'
+__sha__ = 'fa3d2625ac54d06547619bc18a83b4fb5967f3f0190191eae01ff00286cb8004'

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ import platform
 from subprocess import Popen, PIPE
 import sys
 import unittest
+import fileinput
 
 # Read version from local pygit2/version.py without pulling in
 # pygit2/__init__.py
@@ -165,12 +166,16 @@ class build_ext_subclass(build_ext):
                 '-DCMAKE_INSTALL_NAME_DIR:PATH=@loader_path',
                 '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=TRUE',
                 '-DBUILD_CLAR:BOOL=OFF',
-                '-DUSE_ICONV:BOOL=OFF',
-                '-DUSE_SSH:BOOL=OFF',  # caused iconv linking errors?
                 '../libgit2-%s' % ver,
             ]
 
             run_cmd('cmake', cmake_args)
+
+            # bug in libgit2 that is fixed with newer versions
+            for line in fileinput.input('CMakeFiles/git2.dir/flags.make',
+                                        inplace=True):
+                print(line.replace('-DGIT_USE_ICONV', ''), end='')
+
             run_cmd('make', '-j8 all install'.split())
 
             os.chdir(cwd)

--- a/setup.py
+++ b/setup.py
@@ -187,6 +187,8 @@ class build_ext_subclass(build_ext):
                 self.copy_file(os.path.join(lib_path, l + shared_ext),
                                os.path.abspath(self.build_lib))
 
+        # make sure we search our header path first
+        self.compiler.compiler_so.insert(1, '-Ibuild/libgit2/include')
         build_ext.build_extensions(self)
 
 
@@ -239,7 +241,6 @@ setup(name='pygit2',
       packages=['pygit2'],
       ext_modules=[
           Extension('_pygit2', pygit2_exts,
-                    include_dirs=['build/libgit2/include'],
                     extra_link_args=['build/libgit2/lib/libgit2' + shared_ext]),
       ],
       cmdclass=cmdclass)


### PR DESCRIPTION
This is a proof-of-concept (but working!) pull request that downloads and installs libgit2 into the virtualenv for pygit2. By using @loader_path and injecting the header path in setup.py we guarantee that this will not conflict with any globally installed libgit2.

Except for the downloading part, there is already a precedence in pygit2 for installing shared libraries side-by-side on Windows. Once we update to a more modern pygit2, I will break this setup apart and submit most of it upstream.

As for us, I think this is ready to go into the requirements.txt file. The benefits are that we can remove our custom homebrew tap and more easily install things on vagrant / docker.